### PR TITLE
fix(ojilab): align sample-discord-interaction record with DNS side

### DIFF
--- a/ojilab_cloud.tf
+++ b/ojilab_cloud.tf
@@ -62,7 +62,7 @@ resource "cloudflare_record" "ojilabcloud_txt_root_googlesiteverification" {
 }
 
 resource "cloudflare_record" "ojilabcloud_a_cname_sample_discord_interaction" {
-  name    = "sample.discord-interaction"
+  name    = "sample-discord-interaction.ojilab.cloud"
   proxied = true
   ttl     = 1
   type    = "CNAME"


### PR DESCRIPTION
## Summary
- `ojilab_cloud.tf` の `sample.discord-interaction` → `sample-discord-interaction.ojilab.cloud` にリネーム
- Cloudflare 側で Total TLS のサブドメイン depth 制約を避けるためハイフン区切りに変更済み。IaC を実体に追従
- 既存 record (`771087b73ed39d39e2d0e3bdf6e7ec25`) は state に import 済み

## Context
`terraform plan` でこの record の drift が検出されていました（別名で新規作成しようとしていた）。import + rename で差分解消。

## Test plan
- [ ] CI の `terraform plan` で当該 record に差分が出ない
- [ ] apply 後 `sample-discord-interaction.ojilab.cloud` が引き続き cfargotunnel に解決される

🤖 Generated with [Claude Code](https://claude.com/claude-code)